### PR TITLE
Add race data import and analysis dashboard

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,61 +1,80 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# 競馬データ分析システム
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+このアプリケーションは過去レース結果を蓄積し、コース条件から勝ち馬の傾向や投資シミュレーションを行える Laravel 製の管理ツールです。
 
-## About Laravel
+## 主な機能
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+- **CSV インポート**: 競馬場・距離・天候などの条件と出走馬情報、各種払戻データを一括登録。
+- **コース条件フィルタ**: 競馬場・コース種別・距離・天候・馬場状態・回り・開催日で絞り込み可能。
+- **勝ち馬傾向の可視化**: 枠番・馬番・人気・性別・脚質ごとの勝利数／ROI を表示。
+- **3着以内傾向**: 枠番・馬番・人気について最頻値と出現割合を確認。
+- **購入シミュレーション**: 単勝／馬単／馬連／三連単それぞれを 100 円ずつ購入した場合の ROI を算出し、予算 10,000 円の推奨戦略を提示。
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+## セットアップ
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+1. 必要に応じて `.env` を作成し、データベース接続設定を行ってください。
+2. 依存パッケージのインストール
+   ```bash
+   composer install
+   npm install
+   ```
+3. マイグレーション実行
+   ```bash
+   php artisan migrate
+   ```
+4. アプリケーションを起動
+   ```bash
+   php artisan serve
+   ```
 
-## Learning Laravel
+> ※ このリポジトリは Docker / Sail のセットアップが含まれています。コンテナ実行の場合は `docker compose up -d` などご利用の環境に合わせて起動してください。
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+## CSV インポート
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+`/import` 画面から CSV ファイルをアップロードします。1 行に 1 頭分のデータを持つ形式を想定しています。主なカラムは以下の通りです。
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+| 列名 | 説明 |
+| --- | --- |
+| race_date | 開催日（YYYY-MM-DD） |
+| race_name | レース名 |
+| racecourse | 競馬場 |
+| course_type | 芝 / ダート |
+| weather | 天候 |
+| track_condition | 馬場状態 |
+| distance | 距離 (m) |
+| direction | 右 / 左 |
+| number_of_turns | コーナー数 |
+| number_of_runners | 出走頭数 |
+| frame_number | 枠番 |
+| horse_number | 馬番 |
+| horse_name | 馬名 |
+| sex | 性別 |
+| running_style | 脚質 |
+| popularity | 単勝人気 |
+| finish_position | 着順 |
+| win_odds | 単勝オッズ |
+| win_payout | 単勝払戻（100 円） |
+| place_payout | 複勝払戻（100 円） |
+| exacta_combination | 馬単の着順組み合わせ |
+| exacta_payout | 馬単払戻（100 円） |
+| quinella_combination | 馬連の組み合わせ |
+| quinella_payout | 馬連払戻（100 円） |
+| trifecta_combination | 三連単の組み合わせ |
+| trifecta_payout | 三連単払戻（100 円） |
 
-## Laravel Sponsors
+これらの列が存在しない場合でも、利用可能なデータのみ保存されます。
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+## 分析画面
 
-### Premium Partners
+トップページ(`/`)では、指定した条件で過去レースを抽出し、以下の情報を確認できます。
 
-- **[Vehikl](https://vehikl.com)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development)**
-- **[Active Logic](https://activelogic.com)**
+- 条件に合致したレース数・出走頭数・平均単勝人気
+- 枠番・馬番・人気・性別・脚質別の勝利数と ROI
+- 3 着以内の最多出現枠番／馬番／人気
+- 各券種（単勝・馬単・馬連・三連単）の歴史的 ROI と 10,000 円投資時の想定収支
 
-## Contributing
+推奨プランは、ROI が最も高かった券種に 1 レース 100 円ずつ投資した場合の想定結果を文章で提示します。
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+## ライセンス
 
-## Code of Conduct
-
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
-
-## Security Vulnerabilities
-
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
-
-## License
-
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+MIT License

--- a/src/app/Http/Controllers/RaceAnalysisController.php
+++ b/src/app/Http/Controllers/RaceAnalysisController.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Race;
+use App\Models\RaceEntry;
+use App\Models\RacePayout;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class RaceAnalysisController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $filters = $this->buildFilterOptions();
+        $conditions = $this->extractConditions($request);
+
+        $racesQuery = Race::query();
+
+        foreach ($conditions as $column => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if ($column === 'date_from') {
+                $racesQuery->whereDate('race_date', '>=', $value);
+            } elseif ($column === 'date_to') {
+                $racesQuery->whereDate('race_date', '<=', $value);
+            } else {
+                $racesQuery->where($column, $value);
+            }
+        }
+
+        $raceIds = $racesQuery->pluck('id');
+
+        $winners = RaceEntry::query()
+            ->whereIn('race_id', $raceIds)
+            ->where('finish_position', 1)
+            ->get();
+
+        $topThree = RaceEntry::query()
+            ->whereIn('race_id', $raceIds)
+            ->where('finish_position', '<=', 3)
+            ->get();
+
+        $summary = [
+            'total_races' => $raceIds->count(),
+            'total_entries' => $raceIds->isEmpty() ? 0 : RaceEntry::whereIn('race_id', $raceIds)->count(),
+            'average_popularity' => $winners->avg('popularity') ?? 0.0,
+        ];
+
+        $winnerStats = [
+            'frame_number' => $this->buildCountAndRoi($winners, 'frame_number'),
+            'horse_number' => $this->buildCountAndRoi($winners, 'horse_number'),
+            'popularity' => $this->buildCountAndRoi($winners, 'popularity'),
+            'sex' => $this->buildCountAndAverage($winners, 'sex'),
+            'running_style' => $this->buildCountAndAverage($winners, 'running_style'),
+        ];
+
+        $topThreeStats = [
+            'frame_number' => $this->buildTopThreeSummary($topThree, 'frame_number'),
+            'horse_number' => $this->buildTopThreeSummary($topThree, 'horse_number'),
+            'popularity' => $this->buildTopThreeSummary($topThree, 'popularity'),
+        ];
+
+        $investment = $this->buildInvestmentAnalysis($raceIds);
+
+        return view('analysis', [
+            'filters' => $filters,
+            'summary' => $summary,
+            'winnerStats' => $winnerStats,
+            'topThreeStats' => $topThreeStats,
+            'investment' => $investment,
+        ]);
+    }
+
+    /**
+     * @return array<string, Collection<int, string|int>>
+     */
+    private function buildFilterOptions(): array
+    {
+        return [
+            'racecourses' => Race::query()->select('racecourse')->whereNotNull('racecourse')->distinct()->orderBy('racecourse')->pluck('racecourse'),
+            'distances' => Race::query()->select('distance')->where('distance', '>', 0)->distinct()->orderBy('distance')->pluck('distance'),
+            'weathers' => Race::query()->select('weather')->whereNotNull('weather')->distinct()->orderBy('weather')->pluck('weather'),
+            'track_conditions' => Race::query()->select('track_condition')->whereNotNull('track_condition')->distinct()->orderBy('track_condition')->pluck('track_condition'),
+        ];
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function extractConditions(Request $request): array
+    {
+        $conditions = [
+            'racecourse' => $request->string('racecourse')->whenEmpty(null),
+            'course_type' => $request->string('course_type')->whenEmpty(null),
+            'distance' => $request->filled('distance') ? (int) $request->input('distance') : null,
+            'weather' => $request->string('weather')->whenEmpty(null),
+            'track_condition' => $request->string('track_condition')->whenEmpty(null),
+            'direction' => $request->string('direction')->whenEmpty(null),
+            'date_from' => $this->parseDate($request->input('date_from')),
+            'date_to' => $this->parseDate($request->input('date_to')),
+        ];
+
+        return array_filter($conditions, fn ($value) => $value !== null);
+    }
+
+    private function parseDate(?string $value): ?string
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->format('Y-m-d');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  Collection<int, RaceEntry>  $collection
+     * @return array<string, array<string, float|int>>
+     */
+    private function buildCountAndRoi(Collection $collection, string $column): array
+    {
+        return $collection
+            ->groupBy($column)
+            ->filter(fn ($group, $key) => ! in_array($key, [null, '', 0], true))
+            ->map(function (Collection $group) {
+                $investment = max(1, $group->count()) * 100;
+                $payout = (int) $group->sum('win_payout');
+                $roi = $investment === 0 ? 0.0 : $payout / $investment;
+
+                return [
+                    'count' => $group->count(),
+                    'roi' => $roi,
+                ];
+            })
+            ->sortByDesc('count')
+            ->toArray();
+    }
+
+    /**
+     * @param  Collection<int, RaceEntry>  $collection
+     * @return array<string, array<string, float|int>>
+     */
+    private function buildCountAndAverage(Collection $collection, string $column): array
+    {
+        return $collection
+            ->groupBy(function ($item) use ($column) {
+                $value = Arr::get($item, $column);
+
+                return $value === null || $value === '' ? '不明' : $value;
+            })
+            ->map(function (Collection $group) {
+                return [
+                    'count' => $group->count(),
+                    'average_popularity' => $group->avg('popularity') ?? 0.0,
+                ];
+            })
+            ->sortByDesc('count')
+            ->toArray();
+    }
+
+    /**
+     * @param  Collection<int, RaceEntry>  $collection
+     * @return array{value:string|int, count:int, ratio:float}
+     */
+    private function buildTopThreeSummary(Collection $collection, string $column): array
+    {
+        if ($collection->isEmpty()) {
+            return [
+                'value' => 'データなし',
+                'count' => 0,
+                'ratio' => 0.0,
+            ];
+        }
+
+        $group = $collection
+            ->filter(fn ($item) => ! in_array(Arr::get($item, $column), [null, '', 0], true))
+            ->groupBy($column)
+            ->map(fn (Collection $items) => $items->count())
+            ->sortDesc();
+
+        $value = $group->keys()->first();
+        $count = $group->values()->first();
+        $ratio = $collection->count() > 0 ? $count / $collection->count() : 0.0;
+
+        return [
+            'value' => $value,
+            'count' => $count,
+            'ratio' => $ratio,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, int>  $raceIds
+     * @return array{
+     *     budget:int,
+     *     recommendation:?string,
+     *     bet_types:array<string, array{label:string, races:int, investment:int, payout:int, roi:float, expected_return:float}>
+     * }
+     */
+    private function buildInvestmentAnalysis(Collection $raceIds): array
+    {
+        $budget = 10000;
+        $betTypes = [
+            'win' => '単勝',
+            'exacta' => '馬単',
+            'quinella' => '馬連',
+            'trifecta' => '三連単',
+        ];
+
+        $result = [];
+        $best = null;
+
+        foreach ($betTypes as $type => $label) {
+            $payouts = RacePayout::query()
+                ->whereIn('race_id', $raceIds)
+                ->where('bet_type', $type)
+                ->get();
+
+            $races = $payouts->count();
+            $investment = $races * 100;
+            $payout = (int) $payouts->sum('payout');
+            $roi = $investment === 0 ? 0.0 : $payout / $investment;
+            $expectedReturn = $roi * $budget;
+
+            $result[$type] = [
+                'label' => $label,
+                'races' => $races,
+                'investment' => $investment,
+                'payout' => $payout,
+                'roi' => $roi,
+                'expected_return' => $expectedReturn,
+            ];
+
+            if ($races > 0 && ($best === null || $roi > $best['roi'])) {
+                $best = [
+                    'type' => $label,
+                    'roi' => $roi,
+                    'expected_return' => $expectedReturn,
+                ];
+            }
+        }
+
+        $recommendation = null;
+        if ($best !== null) {
+            $profit = $best['expected_return'] - $budget;
+            $recommendation = sprintf(
+                '%sを対象に1レース100円投資した場合の想定ROIは%.2fで、予算を全額投資すると約¥%sの%sになります。',
+                $best['type'],
+                $best['roi'],
+                number_format(abs($profit)),
+                $profit >= 0 ? '利益' : '損失'
+            );
+        }
+
+        return [
+            'budget' => $budget,
+            'bet_types' => $result,
+            'recommendation' => $recommendation,
+        ];
+    }
+}

--- a/src/app/Http/Controllers/RaceImportController.php
+++ b/src/app/Http/Controllers/RaceImportController.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Race;
+use App\Models\RaceEntry;
+use App\Models\RacePayout;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Throwable;
+
+class RaceImportController extends Controller
+{
+    public function create(): View
+    {
+        return view('import');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'csv_file' => ['required', 'file', 'mimetypes:text/plain,text/csv,text/tsv', 'max:10240'],
+        ], [
+            'csv_file.required' => 'CSVファイルを選択してください。',
+            'csv_file.mimetypes' => 'CSV形式のファイルを指定してください。',
+            'csv_file.max' => 'ファイルサイズは10MB以下にしてください。',
+        ]);
+
+        $file = $validated['csv_file'];
+        $path = $file->getRealPath();
+
+        if (! $path || ! file_exists($path)) {
+            return back()->withErrors('ファイルを読み込めませんでした。');
+        }
+
+        $handle = fopen($path, 'r');
+
+        if (! $handle) {
+            return back()->withErrors('CSVファイルを開けませんでした。');
+        }
+
+        $header = null;
+        $line = 0;
+        $imported = [
+            'races' => 0,
+            'entries' => 0,
+            'payouts' => 0,
+        ];
+        $payoutTracker = [];
+
+        try {
+            DB::transaction(function () use ($handle, &$header, &$line, &$imported, &$payoutTracker) {
+                while (($row = fgetcsv($handle)) !== false) {
+                    $line++;
+                    if ($line === 1) {
+                        $header = $this->prepareHeader($row);
+                        continue;
+                    }
+
+                    if (! $header || count($header) === 0) {
+                        continue;
+                    }
+
+                    if ($this->isEmptyRow($row)) {
+                        continue;
+                    }
+
+                    $values = array_slice($row, 0, count($header));
+                    $values = array_pad($values, count($header), null);
+                    $values = array_map(function ($value) {
+                        if ($value === null) {
+                            return null;
+                        }
+
+                        return is_string($value) ? trim($value) : $value;
+                    }, $values);
+                    $record = array_combine($header, $values);
+
+                    if ($record === false) {
+                        continue;
+                    }
+
+                    if (! isset($record['race_date'], $record['racecourse'], $record['horse_number'])) {
+                        continue;
+                    }
+
+                    if ($this->normalizeString($record['racecourse']) === null) {
+                        continue;
+                    }
+
+                    if ($this->toNullableInt($record['horse_number']) === null) {
+                        continue;
+                    }
+
+                    $race = $this->persistRace($record);
+                    if ($race->wasRecentlyCreated) {
+                        $imported['races']++;
+                    }
+
+                    $entry = $this->persistEntry($race, $record);
+                    if ($entry->wasRecentlyCreated) {
+                        $imported['entries']++;
+                    }
+
+                    $imported['payouts'] += $this->persistPayouts($race, $record, $payoutTracker);
+                }
+            });
+        } catch (Throwable $exception) {
+            fclose($handle);
+
+            return back()->withErrors('インポート中にエラーが発生しました: '.$exception->getMessage());
+        }
+
+        fclose($handle);
+
+        return back()->with('status', sprintf('レース:%d件 / 出走馬:%d頭 / 払戻:%d件を登録しました。', $imported['races'], $imported['entries'], $imported['payouts']));
+    }
+
+    /**
+     * @param  array<int, string|null>  $row
+     * @return array<int, string>
+     */
+    private function prepareHeader(array $row): array
+    {
+        $headers = array_map(function ($value) {
+            $value = $value ?? '';
+            $value = trim($value);
+            $value = Str::of($value)->ltrim("\xEF\xBB\xBF")->toString();
+
+            return $value;
+        }, $row);
+
+        if (empty(array_filter($headers))) {
+            return [];
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param  array<int, string|null>  $row
+     */
+    private function isEmptyRow(array $row): bool
+    {
+        return empty(array_filter($row, fn ($value) => $value !== null && trim($value) !== ''));
+    }
+
+    /**
+     * @param  array<string, string|null>  $record
+     */
+    private function persistRace(array $record): Race
+    {
+        $attributes = [
+            'race_date' => Arr::get($record, 'race_date'),
+            'racecourse' => $this->normalizeString(Arr::get($record, 'racecourse')),
+            'race_name' => $this->normalizeString(Arr::get($record, 'race_name')),
+        ];
+
+        $courseType = $this->normalizeString(Arr::get($record, 'course_type'));
+        if ($courseType !== null && ! in_array($courseType, ['芝', 'ダート'], true)) {
+            $courseType = null;
+        }
+
+        $direction = $this->normalizeString(Arr::get($record, 'direction'));
+        if ($direction !== null && ! in_array($direction, ['右', '左'], true)) {
+            $direction = null;
+        }
+
+        $race = Race::firstOrNew($attributes);
+        $race->fill([
+            'course_type' => $courseType,
+            'weather' => $this->normalizeString(Arr::get($record, 'weather')),
+            'track_condition' => $this->normalizeString(Arr::get($record, 'track_condition')),
+            'distance' => (int) Arr::get($record, 'distance', 0),
+            'direction' => $direction,
+            'number_of_turns' => $this->toNullableInt(Arr::get($record, 'number_of_turns')),
+            'number_of_runners' => (int) Arr::get($record, 'number_of_runners', 0),
+        ]);
+        $race->save();
+
+        return $race;
+    }
+
+    /**
+     * @param  array<string, string|null>  $record
+     */
+    private function persistEntry(Race $race, array $record): RaceEntry
+    {
+        $entry = RaceEntry::firstOrNew([
+            'race_id' => $race->id,
+            'horse_number' => (int) Arr::get($record, 'horse_number'),
+        ]);
+
+        $entry->fill([
+            'frame_number' => (int) Arr::get($record, 'frame_number', 0),
+            'horse_name' => $this->normalizeString(Arr::get($record, 'horse_name')),
+            'sex' => $this->normalizeString(Arr::get($record, 'sex')),
+            'running_style' => $this->normalizeString(Arr::get($record, 'running_style')),
+            'popularity' => $this->toNullableInt(Arr::get($record, 'popularity')),
+            'finish_position' => $this->toNullableInt(Arr::get($record, 'finish_position')),
+            'win_odds' => $this->toNullableFloat(Arr::get($record, 'win_odds')),
+            'win_payout' => $this->toNullableInt(Arr::get($record, 'win_payout')),
+            'place_payout' => $this->toNullableInt(Arr::get($record, 'place_payout')),
+        ]);
+
+        $entry->save();
+
+        return $entry;
+    }
+
+    /**
+     * @param  array<string, string|null>  $record
+     * @param  array<string, array<string, bool>>  $tracker
+     */
+    private function persistPayouts(Race $race, array $record, array &$tracker): int
+    {
+        $count = 0;
+        $raceKey = (string) $race->id;
+
+        $payoutDefinitions = [
+            'win' => [
+                'combination' => Arr::get($record, 'horse_number'),
+                'payout' => Arr::get($record, 'win_payout'),
+                'odds' => Arr::get($record, 'win_odds'),
+            ],
+            'exacta' => [
+                'combination' => Arr::get($record, 'exacta_combination'),
+                'payout' => Arr::get($record, 'exacta_payout'),
+            ],
+            'quinella' => [
+                'combination' => Arr::get($record, 'quinella_combination'),
+                'payout' => Arr::get($record, 'quinella_payout'),
+            ],
+            'trifecta' => [
+                'combination' => Arr::get($record, 'trifecta_combination'),
+                'payout' => Arr::get($record, 'trifecta_payout'),
+            ],
+        ];
+
+        foreach ($payoutDefinitions as $betType => $values) {
+            $combination = $this->normalizeString($values['combination'] ?? null);
+            $payout = $this->toNullableInt($values['payout'] ?? null);
+            $odds = $this->toNullableFloat($values['odds'] ?? null);
+
+            if ($combination === null || $payout === null) {
+                continue;
+            }
+
+            $key = $raceKey.'-'.$betType.'-'.$combination;
+
+            if (($tracker[$key] ?? false) === true) {
+                continue;
+            }
+
+            $payoutModel = RacePayout::updateOrCreate([
+                'race_id' => $race->id,
+                'bet_type' => $betType,
+                'combination' => $combination,
+            ], [
+                'payout' => $payout,
+                'odds' => $odds,
+            ]);
+
+            $tracker[$key] = true;
+            if ($payoutModel->wasRecentlyCreated) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    private function toNullableInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function toNullableFloat(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (float) $value;
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/src/app/Models/Race.php
+++ b/src/app/Models/Race.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Race extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'race_date',
+        'race_name',
+        'racecourse',
+        'course_type',
+        'weather',
+        'track_condition',
+        'distance',
+        'direction',
+        'number_of_turns',
+        'number_of_runners',
+    ];
+
+    protected $casts = [
+        'race_date' => 'date',
+        'distance' => 'integer',
+        'number_of_turns' => 'integer',
+        'number_of_runners' => 'integer',
+    ];
+
+    public function entries(): HasMany
+    {
+        return $this->hasMany(RaceEntry::class);
+    }
+
+    public function payouts(): HasMany
+    {
+        return $this->hasMany(RacePayout::class);
+    }
+}

--- a/src/app/Models/RaceEntry.php
+++ b/src/app/Models/RaceEntry.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RaceEntry extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'race_id',
+        'frame_number',
+        'horse_number',
+        'horse_name',
+        'sex',
+        'running_style',
+        'popularity',
+        'finish_position',
+        'win_odds',
+        'win_payout',
+        'place_payout',
+    ];
+
+    protected $casts = [
+        'win_odds' => 'float',
+        'frame_number' => 'integer',
+        'horse_number' => 'integer',
+        'popularity' => 'integer',
+        'finish_position' => 'integer',
+        'win_payout' => 'integer',
+        'place_payout' => 'integer',
+    ];
+
+    public function race(): BelongsTo
+    {
+        return $this->belongsTo(Race::class);
+    }
+}

--- a/src/app/Models/RacePayout.php
+++ b/src/app/Models/RacePayout.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RacePayout extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'race_id',
+        'bet_type',
+        'combination',
+        'odds',
+        'payout',
+    ];
+
+    protected $casts = [
+        'odds' => 'float',
+        'payout' => 'integer',
+    ];
+
+    public function race(): BelongsTo
+    {
+        return $this->belongsTo(Race::class);
+    }
+}

--- a/src/database/migrations/2024_10_04_000001_create_races_table.php
+++ b/src/database/migrations/2024_10_04_000001_create_races_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('races', function (Blueprint $table) {
+            $table->id();
+            $table->date('race_date');
+            $table->string('race_name')->nullable();
+            $table->string('racecourse');
+            $table->enum('course_type', ['芝', 'ダート'])->nullable();
+            $table->string('weather')->nullable();
+            $table->string('track_condition')->nullable();
+            $table->unsignedInteger('distance');
+            $table->enum('direction', ['右', '左'])->nullable();
+            $table->unsignedTinyInteger('number_of_turns')->nullable();
+            $table->unsignedTinyInteger('number_of_runners');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('races');
+    }
+};

--- a/src/database/migrations/2024_10_04_000002_create_race_entries_table.php
+++ b/src/database/migrations/2024_10_04_000002_create_race_entries_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('race_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('race_id')->constrained()->cascadeOnDelete();
+            $table->unsignedTinyInteger('frame_number');
+            $table->unsignedTinyInteger('horse_number');
+            $table->string('horse_name')->nullable();
+            $table->string('sex')->nullable();
+            $table->string('running_style')->nullable();
+            $table->unsignedTinyInteger('popularity')->nullable();
+            $table->unsignedTinyInteger('finish_position')->nullable();
+            $table->decimal('win_odds', 8, 2)->nullable();
+            $table->unsignedInteger('win_payout')->nullable();
+            $table->unsignedInteger('place_payout')->nullable();
+            $table->timestamps();
+
+            $table->index(['race_id', 'finish_position']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('race_entries');
+    }
+};

--- a/src/database/migrations/2024_10_04_000003_create_race_payouts_table.php
+++ b/src/database/migrations/2024_10_04_000003_create_race_payouts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('race_payouts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('race_id')->constrained()->cascadeOnDelete();
+            $table->string('bet_type');
+            $table->string('combination')->nullable();
+            $table->decimal('odds', 8, 2)->nullable();
+            $table->unsignedInteger('payout')->nullable();
+            $table->timestamps();
+
+            $table->index(['race_id', 'bet_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('race_payouts');
+    }
+};

--- a/src/resources/views/analysis.blade.php
+++ b/src/resources/views/analysis.blade.php
@@ -1,0 +1,262 @@
+<x-layouts.app title="コース別分析">
+    <div class="card">
+        <h2>コース条件フィルタ</h2>
+        <form action="{{ route('analysis.index') }}" method="get" style="display:grid; gap:1.25rem;">
+            <div class="grid grid-cols-3">
+                <div>
+                    <label for="racecourse">競馬場</label>
+                    <select id="racecourse" name="racecourse">
+                        <option value="">すべて</option>
+                        @foreach ($filters['racecourses'] as $option)
+                            <option value="{{ $option }}" @selected(request('racecourse') === $option)>{{ $option }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
+                    <label for="course_type">コース種別</label>
+                    <select id="course_type" name="course_type">
+                        <option value="">すべて</option>
+                        <option value="芝" @selected(request('course_type') === '芝')>芝</option>
+                        <option value="ダート" @selected(request('course_type') === 'ダート')>ダート</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="distance">距離</label>
+                    <select id="distance" name="distance">
+                        <option value="">すべて</option>
+                        @foreach ($filters['distances'] as $option)
+                            <option value="{{ $option }}" @selected(request('distance') === (string) $option)>{{ $option }}m</option>
+                        @endforeach
+                    </select>
+                </div>
+            </div>
+            <div class="grid grid-cols-3">
+                <div>
+                    <label for="weather">天候</label>
+                    <select id="weather" name="weather">
+                        <option value="">すべて</option>
+                        @foreach ($filters['weathers'] as $option)
+                            <option value="{{ $option }}" @selected(request('weather') === $option)>{{ $option }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
+                    <label for="track_condition">馬場状態</label>
+                    <select id="track_condition" name="track_condition">
+                        <option value="">すべて</option>
+                        @foreach ($filters['track_conditions'] as $option)
+                            <option value="{{ $option }}" @selected(request('track_condition') === $option)>{{ $option }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
+                    <label for="direction">回り</label>
+                    <select id="direction" name="direction">
+                        <option value="">すべて</option>
+                        <option value="右" @selected(request('direction') === '右')>右</option>
+                        <option value="左" @selected(request('direction') === '左')>左</option>
+                    </select>
+                </div>
+            </div>
+            <div>
+                <label for="date_from">開催日（開始）</label>
+                <input type="date" id="date_from" name="date_from" value="{{ request('date_from') }}">
+            </div>
+            <div>
+                <label for="date_to">開催日（終了）</label>
+                <input type="date" id="date_to" name="date_to" value="{{ request('date_to') }}">
+            </div>
+            <div>
+                <button type="submit">分析する</button>
+            </div>
+        </form>
+    </div>
+
+    @if ($summary['total_races'] > 0)
+        <div class="card">
+            <h2>該当レース概要</h2>
+            <div class="grid grid-cols-3">
+                <div class="stat-card">
+                    <h3>対象レース数</h3>
+                    <p><strong>{{ number_format($summary['total_races']) }}</strong> レース</p>
+                </div>
+                <div class="stat-card">
+                    <h3>集計対象頭数</h3>
+                    <p><strong>{{ number_format($summary['total_entries']) }}</strong> 頭</p>
+                </div>
+                <div class="stat-card">
+                    <h3>平均単勝人気</h3>
+                    <p><strong>{{ number_format($summary['average_popularity'], 1) }}</strong> 番人気</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h2>優勝馬の傾向</h2>
+            <div class="grid grid-cols-3">
+                <div>
+                    <h3 style="margin-bottom:0.75rem;">枠番別勝利数</h3>
+                    <table>
+                        <thead>
+                            <tr><th>枠番</th><th>勝利数</th><th>ROI</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($winnerStats['frame_number'] as $frame => $data)
+                                <tr>
+                                    <td>{{ $frame }}</td>
+                                    <td>{{ $data['count'] }}</td>
+                                    <td>{{ number_format($data['roi'], 2) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                <div>
+                    <h3 style="margin-bottom:0.75rem;">馬番別勝利数</h3>
+                    <table>
+                        <thead>
+                            <tr><th>馬番</th><th>勝利数</th><th>ROI</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($winnerStats['horse_number'] as $number => $data)
+                                <tr>
+                                    <td>{{ $number }}</td>
+                                    <td>{{ $data['count'] }}</td>
+                                    <td>{{ number_format($data['roi'], 2) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                <div>
+                    <h3 style="margin-bottom:0.75rem;">人気別勝利数</h3>
+                    <table>
+                        <thead>
+                            <tr><th>人気</th><th>勝利数</th><th>ROI</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($winnerStats['popularity'] as $popularity => $data)
+                                <tr>
+                                    <td>{{ $popularity }}</td>
+                                    <td>{{ $data['count'] }}</td>
+                                    <td>{{ number_format($data['roi'], 2) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="grid grid-cols-2" style="margin-top:1.5rem;">
+                <div>
+                    <h3 style="margin-bottom:0.75rem;">性別別勝利数</h3>
+                    <table>
+                        <thead>
+                            <tr><th>性別</th><th>勝利数</th><th>平均人気</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($winnerStats['sex'] as $sex => $data)
+                                <tr>
+                                    <td>{{ $sex ?: '不明' }}</td>
+                                    <td>{{ $data['count'] }}</td>
+                                    <td>{{ number_format($data['average_popularity'], 1) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                <div>
+                    <h3 style="margin-bottom:0.75rem;">脚質別勝利数</h3>
+                    <table>
+                        <thead>
+                            <tr><th>脚質</th><th>勝利数</th><th>平均人気</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($winnerStats['running_style'] as $style => $data)
+                                <tr>
+                                    <td>{{ $style ?: '不明' }}</td>
+                                    <td>{{ $data['count'] }}</td>
+                                    <td>{{ number_format($data['average_popularity'], 1) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h2>3着以内の傾向</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>指標</th>
+                        <th>最多出現</th>
+                        <th>出現回数</th>
+                        <th>割合</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>枠番</td>
+                        <td>{{ $topThreeStats['frame_number']['value'] }}</td>
+                        <td>{{ $topThreeStats['frame_number']['count'] }}</td>
+                        <td>{{ number_format($topThreeStats['frame_number']['ratio'] * 100, 1) }}%</td>
+                    </tr>
+                    <tr>
+                        <td>馬番</td>
+                        <td>{{ $topThreeStats['horse_number']['value'] }}</td>
+                        <td>{{ $topThreeStats['horse_number']['count'] }}</td>
+                        <td>{{ number_format($topThreeStats['horse_number']['ratio'] * 100, 1) }}%</td>
+                    </tr>
+                    <tr>
+                        <td>人気</td>
+                        <td>{{ $topThreeStats['popularity']['value'] }}</td>
+                        <td>{{ $topThreeStats['popularity']['count'] }}</td>
+                        <td>{{ number_format($topThreeStats['popularity']['ratio'] * 100, 1) }}%</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="card">
+            <h2>購入シミュレーション（予算: ¥10,000）</h2>
+            <p style="color:#4b5563; font-size:0.95rem;">対象レースにおいて勝ち組み合わせへ毎回100円ずつ投票した場合の収支シミュレーションです。</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>券種</th>
+                        <th>対象レース数</th>
+                        <th>投資額</th>
+                        <th>払戻合計</th>
+                        <th>ROI</th>
+                        <th>10,000円投資時の期待収支</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($investment['bet_types'] as $type => $data)
+                        <tr>
+                            <td>{{ $data['label'] }}</td>
+                            <td>{{ $data['races'] }}</td>
+                            <td>¥{{ number_format($data['investment']) }}</td>
+                            <td>¥{{ number_format($data['payout']) }}</td>
+                            <td>{{ number_format($data['roi'], 2) }}</td>
+                            <td>¥{{ number_format($data['expected_return'] - $investment['budget']) }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+
+            @if ($investment['recommendation'])
+                <div class="stat-card" style="margin-top:1.5rem;">
+                    <h3>推奨プラン</h3>
+                    <p>{{ $investment['recommendation'] }}</p>
+                </div>
+            @endif
+        </div>
+    @else
+        <div class="card">
+            <h2>該当データがありません</h2>
+            <p style="color:#4b5563; font-size:0.95rem;">条件を変更して再度検索してください。</p>
+        </div>
+    @endif
+</x-layouts.app>

--- a/src/resources/views/components/layouts/app.blade.php
+++ b/src/resources/views/components/layouts/app.blade.php
@@ -1,0 +1,204 @@
+@props(['title' => '競馬データ分析システム'])
+
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ $title }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            color-scheme: light dark;
+        }
+        * {
+            box-sizing: border-box;
+            font-family: 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        }
+        body {
+            margin: 0;
+            background: #f6f7fb;
+            color: #1b1f24;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+        header {
+            background: #1f2937;
+            color: #fff;
+            padding: 1rem 1.5rem;
+        }
+        header h1 {
+            margin: 0;
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+        nav {
+            margin-top: 0.75rem;
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+        nav a {
+            color: #d1d5db;
+            text-decoration: none;
+            font-size: 0.95rem;
+        }
+        nav a:hover {
+            color: #fff;
+        }
+        main {
+            flex: 1;
+            padding: 2rem 1.5rem 3rem;
+            max-width: 1200px;
+            width: 100%;
+            margin: 0 auto;
+        }
+        .card {
+            background: #fff;
+            border-radius: 12px;
+            padding: 1.5rem;
+            box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+            margin-bottom: 2rem;
+        }
+        .card h2 {
+            margin-top: 0;
+            font-size: 1.35rem;
+            color: #111827;
+        }
+        label {
+            font-weight: 600;
+            display: block;
+            margin-bottom: 0.35rem;
+        }
+        input[type="text"],
+        input[type="number"],
+        input[type="date"],
+        select,
+        textarea {
+            width: 100%;
+            padding: 0.65rem 0.75rem;
+            border-radius: 8px;
+            border: 1px solid #d1d5db;
+            font-size: 0.95rem;
+            transition: border-color 0.2s ease;
+            background: #fff;
+        }
+        input:focus, select:focus, textarea:focus {
+            outline: none;
+            border-color: #2563eb;
+            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+        }
+        button {
+            border: none;
+            border-radius: 8px;
+            padding: 0.75rem 1.5rem;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            background: #2563eb;
+            color: #fff;
+            transition: background 0.2s ease;
+        }
+        button:hover {
+            background: #1d4ed8;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 1rem;
+        }
+        table th, table td {
+            border: 1px solid #e5e7eb;
+            padding: 0.6rem 0.75rem;
+            text-align: center;
+            font-size: 0.9rem;
+        }
+        table th {
+            background: #f3f4f6;
+            font-weight: 700;
+        }
+        .alert {
+            padding: 0.85rem 1rem;
+            border-radius: 8px;
+            margin-bottom: 1.5rem;
+            font-weight: 600;
+        }
+        .alert-success {
+            background: #dcfce7;
+            color: #166534;
+        }
+        .alert-error {
+            background: #fee2e2;
+            color: #991b1b;
+        }
+        .grid {
+            display: grid;
+            gap: 1.5rem;
+        }
+        @media (min-width: 768px) {
+            .grid-cols-2 {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+            .grid-cols-3 {
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+            }
+        }
+        .stat-card {
+            background: #f9fafb;
+            border-radius: 10px;
+            padding: 1rem 1.25rem;
+            border: 1px solid #e5e7eb;
+        }
+        .stat-card h3 {
+            margin: 0 0 0.5rem;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+        .stat-card p {
+            margin: 0.15rem 0;
+            color: #4b5563;
+            font-size: 0.95rem;
+        }
+        footer {
+            text-align: center;
+            padding: 1.5rem 0;
+            color: #6b7280;
+            font-size: 0.9rem;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>競馬データ分析システム</h1>
+        <nav>
+            <a href="{{ route('analysis.index') }}">分析ダッシュボード</a>
+            <a href="{{ route('import.create') }}">CSVインポート</a>
+        </nav>
+    </header>
+    <main>
+        @if (session('status'))
+            <div class="alert alert-success">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        @if ($errors->any())
+            <div class="alert alert-error">
+                <ul style="margin:0; padding-left:1.25rem;">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        {{ $slot }}
+    </main>
+    <footer>
+        &copy; {{ date('Y') }} Keiba System
+    </footer>
+</body>
+</html>

--- a/src/resources/views/import.blade.php
+++ b/src/resources/views/import.blade.php
@@ -1,0 +1,57 @@
+<x-layouts.app title="CSVインポート">
+    <div class="card">
+        <h2>レースデータCSVインポート</h2>
+        <p style="color:#4b5563; font-size:0.95rem;">過去レースの実績データをCSVで取り込みます。1行に1頭分のレコードが含まれる形式を想定しています。</p>
+        <form action="{{ route('import.store') }}" method="post" enctype="multipart/form-data" style="margin-top:1.5rem; display:grid; gap:1rem; max-width:480px;">
+            @csrf
+            <div>
+                <label for="csv_file">CSVファイル</label>
+                <input type="file" id="csv_file" name="csv_file" accept=".csv,text/csv">
+            </div>
+            <div>
+                <button type="submit">インポートを実行</button>
+            </div>
+        </form>
+    </div>
+
+    <div class="card">
+        <h2>CSVフォーマット</h2>
+        <p style="color:#4b5563; font-size:0.95rem;">以下のヘッダ名を持つUTF-8のCSVを想定しています。不要な列があっても構いませんが、最低限レース識別に必要な列（開催日、競馬場、距離、頭数、馬番など）はご用意ください。</p>
+        <table>
+            <thead>
+                <tr>
+                    <th>列名</th>
+                    <th>説明</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td>race_date</td><td>開催日（YYYY-MM-DD）</td></tr>
+                <tr><td>race_name</td><td>レース名（任意）</td></tr>
+                <tr><td>racecourse</td><td>競馬場</td></tr>
+                <tr><td>course_type</td><td>芝 / ダート</td></tr>
+                <tr><td>weather</td><td>天候</td></tr>
+                <tr><td>track_condition</td><td>馬場状態</td></tr>
+                <tr><td>distance</td><td>距離 (m)</td></tr>
+                <tr><td>direction</td><td>右 / 左</td></tr>
+                <tr><td>number_of_turns</td><td>コーナー数（任意）</td></tr>
+                <tr><td>number_of_runners</td><td>出走頭数</td></tr>
+                <tr><td>frame_number</td><td>枠番</td></tr>
+                <tr><td>horse_number</td><td>馬番</td></tr>
+                <tr><td>horse_name</td><td>馬名</td></tr>
+                <tr><td>sex</td><td>性別</td></tr>
+                <tr><td>running_style</td><td>脚質（逃げ・先行など）</td></tr>
+                <tr><td>popularity</td><td>単勝人気</td></tr>
+                <tr><td>finish_position</td><td>着順</td></tr>
+                <tr><td>win_odds</td><td>単勝オッズ</td></tr>
+                <tr><td>win_payout</td><td>単勝払戻（100円）</td></tr>
+                <tr><td>place_payout</td><td>複勝払戻（100円）</td></tr>
+                <tr><td>exacta_combination</td><td>馬単の着順組み合わせ</td></tr>
+                <tr><td>exacta_payout</td><td>馬単払戻（100円）</td></tr>
+                <tr><td>quinella_combination</td><td>馬連の組み合わせ</td></tr>
+                <tr><td>quinella_payout</td><td>馬連払戻（100円）</td></tr>
+                <tr><td>trifecta_combination</td><td>三連単の組み合わせ</td></tr>
+                <tr><td>trifecta_payout</td><td>三連単払戻（100円）</td></tr>
+            </tbody>
+        </table>
+    </div>
+</x-layouts.app>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
+use App\Http\Controllers\RaceAnalysisController;
+use App\Http\Controllers\RaceImportController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::redirect('/welcome', '/');
+
+Route::get('/', [RaceAnalysisController::class, 'index'])->name('analysis.index');
+
+Route::get('/import', [RaceImportController::class, 'create'])->name('import.create');
+Route::post('/import', [RaceImportController::class, 'store'])->name('import.store');


### PR DESCRIPTION
## Summary
- create migrations and Eloquent models for races, entries, and payouts so historical data can be stored
- add CSV import workflow with validation and normalization to persist race information and ticket payouts
- build analysis dashboard with filtering, trend tables, and investment simulation plus shared layout styling
- document application setup, CSV format, and analysis features in the project README

## Testing
- not run (composer install requires GitHub downloads that are blocked in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e1270f700883278da3692d8c876553